### PR TITLE
added port to reflect changes in wge monitoring server

### DIFF
--- a/monitoring/weave-gitops/weave-gitops-podmonitor.yaml
+++ b/monitoring/weave-gitops/weave-gitops-podmonitor.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: monitoring
     app.kubernetes.io/part-of: flux
-    kustomize.toolkit.fluxcd.io/name: monitoring-config
-    kustomize.toolkit.fluxcd.io/namespace: flux-system
   name: weave-gitops
   namespace: monitoring
 spec:
@@ -14,6 +12,8 @@ spec:
       - flux-system
   podMetricsEndpoints:
     - port: http-metrics
+    - port: monitoring
+
   selector:
     matchExpressions:
       - key: app.kubernetes.io/part-of

--- a/monitoring/weave-gitops/weave-gitops-podmonitor.yaml
+++ b/monitoring/weave-gitops/weave-gitops-podmonitor.yaml
@@ -13,7 +13,6 @@ spec:
   podMetricsEndpoints:
     - port: http-metrics
     - port: monitoring
-
   selector:
     matchExpressions:
       - key: app.kubernetes.io/part-of


### PR DESCRIPTION
given we have changed the default port name in 
https://github.com/weaveworks/weave-gitops-enterprise/pull/3500

this pr reflects that in the monitoring config