### PR TITLE
Add monitoring to object cleaner

### DIFF
--- a/monitoring/weave-gitops/dashboards/explorer.json
+++ b/monitoring/weave-gitops/dashboards/explorer.json
@@ -1178,6 +1178,176 @@
       "yaxis": {
         "align": true
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "hiddenSeries": false,
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.0.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(objects_cleaner_latency_seconds_count[2m])) by (action)",
+          "legendFormat": "{{action}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Objects Cleaner Request Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:384",
+          "format": "short"
+        },
+        {
+          "$$hashKey": "object:385",
+          "format": "short"
+        }
+      ],
+      "yaxis": {
+        "align": true
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "hiddenSeries": false,
+      "id": 23,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.0.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(objects_cleaner_latency_seconds_sum{status=\"success\"}[2m])) / sum(rate(objects_cleaner_latency_seconds_count{status=\"success\"}[2m]))\n",
+          "legendFormat": "success",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Objects Cleaner Requests Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:725",
+          "format": "s",
+          "label": "Latency",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:726",
+          "format": "short"
+        }
+      ],
+      "yaxis": {
+        "align": true
+      }
     }
   ],
   "refresh": "5s",


### PR DESCRIPTION
Part of https://github.com/weaveworks/weave-gitops-enterprise/issues/3043

- Added Grafana dashboard panels ("Objects Cleaner Request Rate" and "Objects Cleaner Requests Duration") for the object cleaner component of Explorer., similar to Indexer Writes panels.

Testing:
To test this PR, please check out the following enterprise PR:
https://github.com/weaveworks/weave-gitops-enterprise/pull/3608
and update the main branch in `tools/dev-resources/monitoring/wge-monitoring.yaml`
https://github.com/weaveworks/weave-gitops-enterprise/blob/2fb73de213943d3fc0763b42435a88bc3a531114/tools/dev-resources/monitoring/wge-monitoring.yaml#L9
to the current branch:
```
branch: WGE3043-add-monitoring-to-object-cleaner
```
