### PR TITLE
moving from rules to rbac to see the right collector name

### DIFF
--- a/monitoring/weave-gitops/dashboards/explorer.json
+++ b/monitoring/weave-gitops/dashboards/explorer.json
@@ -802,7 +802,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "collector_cluster_watcher{collector=\"roles\"}",
+          "expr": "collector_cluster_watcher{collector=\"rbac\"}",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/3416

Changed collector name to rbac as it is the expected one. 
Once updated, we could see metrics in grafana 

![Screenshot 2023-12-04 at 15 57 43](https://github.com/weaveworks/weave-gitops-quickstart/assets/12957664/4b2c9b28-5106-4b65-a93c-517aa44852ea)
